### PR TITLE
Fix basic errors

### DIFF
--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -826,7 +826,7 @@ class FakeReleasePlanCustomCommand {
       access: "restricted",
       baseBranch: "master",
       packageLifecycleCommmands: {
-        "pkg-a": {version: 'cargo release'}
+        "pkg-a": { version: "cargo release" }
       }
     };
 
@@ -846,7 +846,7 @@ class FakeReleasePlanCustomCommand {
 describe("apply release plan considering custom command", () => {
   it("will return a null packageJson", async () => {
     const releasePlan = new FakeReleasePlanCustomCommand();
-  
+
     let { changedFiles } = await testSetup(
       "simple-project-custom-command",
       releasePlan.getReleasePlan(),
@@ -858,8 +858,8 @@ describe("apply release plan considering custom command", () => {
     );
 
     if (!readmePath) throw new Error(`could not find an updated changelog`);
-  })
-})
+  });
+});
 
 // MAKE SURE BOTH OF THESE ARE COVERED
 

--- a/packages/apply-release-plan/src/index.test.ts
+++ b/packages/apply-release-plan/src/index.test.ts
@@ -825,7 +825,7 @@ class FakeReleasePlanCustomCommand {
       linked: [],
       access: "restricted",
       baseBranch: "master",
-      packageLifecycleCommmands: {
+      packageLifecycleCommands: {
         "pkg-a": { version: "cargo release" }
       }
     };
@@ -846,7 +846,6 @@ class FakeReleasePlanCustomCommand {
 describe("apply release plan considering custom command", () => {
   it("will return a null packageJson", async () => {
     const releasePlan = new FakeReleasePlanCustomCommand();
-
     let { changedFiles } = await testSetup(
       "simple-project-custom-command",
       releasePlan.getReleasePlan(),

--- a/packages/apply-release-plan/src/index.ts
+++ b/packages/apply-release-plan/src/index.ts
@@ -90,18 +90,26 @@ export default async function applyReleasePlan(
     version: newVersion
   }));
 
-  let customCommands = []
+  let customCommands = [];
   // iterate over releases updating packages
   let finalisedRelease = releaseWithChangelogs.map(release => {
-    if (!!config.packageLifecycleCommands && !!config.packageLifecycleCommands[release.name]) {
-      customCommands.push(spawn(`${config.packageLifecycleCommands[release.name].version} ${release.type}`, { cwd: release.dir }))
-      return { ...release, packageJson: null }
+    if (
+      !!config.packageLifecycleCommands &&
+      !!config.packageLifecycleCommands[release.name]
+    ) {
+      customCommands.push(
+        spawn(
+          `${config.packageLifecycleCommands[release.name].version} ${release.type}`,
+          { cwd: release.dir }
+        )
+      );
+      return { ...release, packageJson: null };
     } else {
       return versionPackage(release, versionsToUpdate);
     }
   });
 
-  await Promise.all(customCommands)
+  await Promise.all(customCommands);
 
   let prettierConfig = await prettier.resolveConfig(cwd);
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -12,8 +12,7 @@ export let defaultWrittenConfig = {
   commit: false,
   linked: [] as ReadonlyArray<ReadonlyArray<string>>,
   access: "restricted",
-  baseBranch: "master",
-  packageLifecycleCommands: {}
+  baseBranch: "master"
 } as const;
 
 function getNormalisedChangelogOption(

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -142,7 +142,7 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
   if (messages.length) {
     throw new ValidationError(
       `Some errors occurred when validating the changesets config:\n` +
-      messages.join("\n")
+        messages.join("\n")
     );
   }
   let config: Config = {
@@ -163,8 +163,10 @@ export let parse = (json: WrittenConfig, packages: Packages): Config => {
       json.baseBranch === undefined
         ? defaultWrittenConfig.baseBranch
         : json.baseBranch,
-    packageLifecycleCommands: json.packageLifecycleCommands === undefined ?
-      defaultWrittenConfig.packageLifecycleCommands : json.packageLifecycleCommands
+    packageLifecycleCommands:
+      json.packageLifecycleCommands === undefined
+        ? defaultWrittenConfig.packageLifecycleCommands
+        : json.packageLifecycleCommands
   };
   return config;
 };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -61,6 +61,7 @@ export type Config = {
   linked: Linked;
   access: AccessType;
   baseBranch: string;
+  packageLifecycleCommands?: Record<string, PackageLifecycleCommands>;
 };
 
 export type WrittenConfig = {
@@ -69,6 +70,7 @@ export type WrittenConfig = {
   linked?: Linked;
   access?: AccessType;
   baseBranch?: string;
+  packageLifecycleCommands?: Record<string, PackageLifecycleCommands>;
 };
 
 export type NewChangesetWithCommit = NewChangeset & { commit?: string };
@@ -102,4 +104,8 @@ export type PreState = {
     [pkgName: string]: string;
   };
   changesets: string[];
+};
+
+export type PackageLifecycleCommands = {
+  version?: string;
 };


### PR DESCRIPTION
Hi @jbolda ,

Took a look at your PR today. There were linting and type issues that caused most of the CI errors. I've fixed all of those.

There's one final failing test (error message below). I believe it's because `packages/apply-release-command/src/index.test.ts` calls for a fixture `"simple-project-custom-command"` which does not exist in `__fixtures__`. Not sure what the best way to address this is so I'm leaving it to you.

```
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received type object
      at Object.copy (node_modules/jest-fixtures/node_modules/fs-extra/lib/copy/copy.js:27:28)
      at Object.copy (node_modules/universalify/index.js:5:67)
      at cb (node_modules/jest-fixtures/index.js:35:29)
      at AnyPromise (node_modules/typeable-promisify/index.js:13:3)
      at promisify (node_modules/typeable-promisify/index.js:12:40)
      at copyDir (node_modules/jest-fixtures/index.js:35:10)
      at createTempDir.then.tempDir (node_modules/jest-fixtures/index.js:39:42)
```